### PR TITLE
feat: add MapLibre GL JS dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "maplibre-gl": ">=5.0.0"
   },
   "devDependencies": {
-    "@types/geojson": "^7946.0.15",
     "maplibre-gl": "^5.7.1",
     "typescript": "~5.8.3",
     "vite": "^7.1.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     devDependencies:
-      '@types/geojson':
-        specifier: ^7946.0.15
-        version: 7946.0.16
       maplibre-gl:
         specifier: ^5.7.1
         version: 5.7.1


### PR DESCRIPTION
## Summary

This PR adds the required dependencies for the MockGeolocateControl library:

### Changes
- **Add maplibre-gl ^5.7.1** as devDependency for development and testing
- **Add maplibre-gl >=5.0.0** as peerDependency to specify compatibility requirements for users
- **Install all dependencies** with pnpm

### Rationale
- **peerDependency**: Ensures users have MapLibre GL JS v5.0.0+ for modern API compatibility
- **devDependency**: Allows development and testing with the latest stable version (5.7.1)

### Updated (Latest Commit)
- **Removed @types/geojson**: This dependency was added incorrectly as we don't actually import or use GeoJSON TypeScript interfaces. We create plain objects that happen to follow GeoJSON structure for MapLibre GL JS, but don't need the typed interfaces.

### Next Steps
This sets up the foundation for implementing the MockGeolocateControl class in subsequent PRs.

### Testing
- [x] Dependencies install successfully with pnpm
- [x] No conflicts with existing build configuration  
- [x] Build works without @types/geojson dependency
- [x] Package remains lean without unused dependencies