### PR TITLE
feat: implement trigger() method to show markers

### DIFF
--- a/src/MockGeolocateControl.ts
+++ b/src/MockGeolocateControl.ts
@@ -17,6 +17,10 @@ import type {
  * A MapLibre GL control that displays a user position marker at specified coordinates
  * without requiring the browser's geolocation API.
  *
+ * Unlike the native GeolocateControl, this mock version does not support tracking mode
+ * since it works with static, predefined coordinates. Each trigger simply shows/updates
+ * the marker position without continuous location updates.
+ *
  * @example
  * ```typescript
  * const mockGeolocateControl = new MockGeolocateControl({


### PR DESCRIPTION
## Overview
This PR implements the basic trigger() functionality for MockGeolocateControl, matching the behavior of MapLibre's native GeolocateControl when `trackUserLocation: false`.

## Changes
- Implement proper `_onClick()` handler to show markers
- Remove placeholder console.log statements  
- Fire `geolocate` event when triggered
- Make `trigger()` delegate to click handler

## Behavior
Similar to the original GeolocateControl with `trackUserLocation: false`:
- **First click**: Shows markers at mock position
- **Subsequent clicks**: Updates marker position (markers remain visible)
- **No toggle behavior**: Markers stay on the map once shown

This is a minimal, focused change that provides the foundation for future enhancements.

## Related
- Continues from PR #16 (visual markers)
- Part of step-by-step implementation approach