### PR TITLE
feat: add zoom-to-location functionality

### DIFF
--- a/src/MockGeolocateControl.ts
+++ b/src/MockGeolocateControl.ts
@@ -1,5 +1,6 @@
 import {
   LngLat,
+  LngLatBounds,
   Marker,
   type IControl,
   type Map,
@@ -270,12 +271,15 @@ export class MockGeolocateControl implements IControl {
   }
 
   /**
-   * Handle button click event - shows/updates marker position
+   * Handle button click event - shows/updates marker position and zooms to location
    * @private
    */
   private _onClick(): void {
     // Show markers (or update their position if already shown)
     this._showMarkers();
+
+    // Zoom to the mock location with accuracy
+    this._zoomToPosition();
 
     // Fire geolocate event
     const eventData: GeolocateEventData = {
@@ -286,6 +290,20 @@ export class MockGeolocateControl implements IControl {
       },
     };
     this._fire("geolocate", eventData);
+  }
+
+  /**
+   * Zoom the map to the mock position with accuracy radius
+   * @private
+   */
+  private _zoomToPosition(): void {
+    if (!this._map) return;
+
+    // Create bounds from position and accuracy radius
+    const bounds = LngLatBounds.fromLngLat(this._position, this._accuracy);
+
+    // Fit the map to the bounds with configured options
+    this._map.fitBounds(bounds, this._fitBoundsOptions);
   }
 
   /**


### PR DESCRIPTION
## Overview
This PR adds automatic zoom-to-location behavior when the geolocate button is clicked, matching the behavior of the native GeolocateControl.

## Changes
- Add `_zoomToPosition()` method to zoom map to mock location
- Use `fitBounds()` with accuracy radius to properly frame the location
- Respect `fitBoundsOptions` configuration (default maxZoom: 15)

## Behavior
When the button is clicked or `trigger()` is called:
1. Shows markers at mock position
2. **Zooms the map to fit the position and accuracy circle**
3. Fires `geolocate` event

The zoom level is automatically calculated based on the accuracy radius, constrained by `fitBoundsOptions.maxZoom` (default 15).

## Testing
The control now provides the expected "center on my location" behavior that users are familiar with from the native GeolocateControl.

## Related
- Builds on PR #19 (trigger implementation)
- Small, focused change following step-by-step approach