### PR TITLE
refactor: align trigger/click structure with original GeolocateControl

### DIFF
--- a/src/MockGeolocateControl.ts
+++ b/src/MockGeolocateControl.ts
@@ -271,25 +271,11 @@ export class MockGeolocateControl implements IControl {
   }
 
   /**
-   * Handle button click event - shows/updates marker position and zooms to location
+   * Handle button click event
    * @private
    */
   private _onClick(): void {
-    // Show markers (or update their position if already shown)
-    this._showMarkers();
-
-    // Zoom to the mock location with accuracy
-    this._zoomToPosition();
-
-    // Fire geolocate event
-    const eventData: GeolocateEventData = {
-      coords: {
-        latitude: this._position.lat,
-        longitude: this._position.lng,
-        accuracy: this._accuracy,
-      },
-    };
-    this._fire("geolocate", eventData);
+    this.trigger();
   }
 
   /**
@@ -308,10 +294,24 @@ export class MockGeolocateControl implements IControl {
 
   /**
    * Programmatically trigger the geolocate control
-   * Shows or updates the marker position
+   * Shows markers and centers the map on the mock position
    */
   trigger(): void {
-    this._onClick();
+    // Show markers (or update their position if already shown)
+    this._showMarkers();
+
+    // Zoom to the mock location with accuracy
+    this._zoomToPosition();
+
+    // Fire geolocate event
+    const eventData: GeolocateEventData = {
+      coords: {
+        latitude: this._position.lat,
+        longitude: this._position.lng,
+        accuracy: this._accuracy,
+      },
+    };
+    this._fire("geolocate", eventData);
   }
 
   /**


### PR DESCRIPTION
## Overview
This PR refactors the relationship between `_onClick()` and `trigger()` to match the pattern used in MapLibre's original GeolocateControl.

## Changes
- Move all geolocation logic from `_onClick()` to `trigger()`
- Make `_onClick()` simply call `trigger()`
- No behavior changes - pure refactoring

## Why This Change?
The original GeolocateControl structures it this way:
```javascript
// Click handler just delegates:
this._geolocateButton.addEventListener('click', () => this.trigger());

// trigger() contains the actual logic
trigger() {
  // All the geolocation logic here
}
```

This pattern is better because:
1. **Semantic correctness**: `trigger()` is the method that actually "triggers" the behavior
2. **Single responsibility**: `_onClick()` is just an event handler, not business logic  
3. **Better API**: The public method does the work, not a private method
4. **Consistency**: Matches the original MapLibre implementation

## Testing
No behavior changes - the control works exactly the same. This is purely a code organization improvement.

## Related
- Follows PR #20 (zoom functionality)
- Improves code structure to match MapLibre patterns