### PR TITLE
fix: prevent redundant marker additions to map

### DIFF
--- a/src/MockGeolocateControl.ts
+++ b/src/MockGeolocateControl.ts
@@ -49,6 +49,9 @@ export class MockGeolocateControl implements IControl {
   private _positionMarker?: Marker;
   private _accuracyMarker?: Marker;
 
+  // Track if markers are shown on the map
+  private _markersOnMap = false;
+
   // Track if we've set up map event listeners
   private _mapEventListenersSetup = false;
 
@@ -146,6 +149,9 @@ export class MockGeolocateControl implements IControl {
       this._accuracyMarker = undefined;
     }
 
+    // Reset marker state
+    this._markersOnMap = false;
+
     // Clean up references
     this._container = undefined;
     this._button = undefined;
@@ -185,15 +191,24 @@ export class MockGeolocateControl implements IControl {
   private _showMarkers(): void {
     if (!this._map) return;
 
-    // Add accuracy circle first (so it appears behind the dot)
-    if (this._accuracyMarker && this._showAccuracyCircle) {
-      this._accuracyMarker.addTo(this._map);
-      this._updateAccuracyCircle();
+    // Only add markers if they're not already on the map
+    if (!this._markersOnMap) {
+      // Add accuracy circle first (so it appears behind the dot)
+      if (this._accuracyMarker && this._showAccuracyCircle) {
+        this._accuracyMarker.addTo(this._map);
+      }
+
+      // Add position dot on top
+      if (this._positionMarker) {
+        this._positionMarker.addTo(this._map);
+      }
+
+      this._markersOnMap = true;
     }
 
-    // Add position dot on top
-    if (this._positionMarker) {
-      this._positionMarker.addTo(this._map);
+    // Always update accuracy circle size (in case zoom changed)
+    if (this._accuracyMarker && this._showAccuracyCircle) {
+      this._updateAccuracyCircle();
     }
 
     // Setup map event listeners for accuracy circle updates


### PR DESCRIPTION
## Overview
This PR optimizes the marker display logic to avoid redundant `addTo()` calls when markers are already on the map.

## Problem
When `trigger()` is called multiple times, `_showMarkers()` was calling `addTo()` every time, even if markers were already displayed. While MapLibre handles this gracefully (removes and re-adds), it's inefficient.

## Solution
- Add `_markersOnMap` flag to track marker display state
- Only call `addTo()` when markers aren't already on the map
- Still update accuracy circle size on each trigger (needed for zoom changes)
- Reset flag when control is removed

## Benefits
- Avoids unnecessary DOM manipulations
- More efficient repeated triggers
- Cleaner, more intentional code

## Testing
Clicking the button multiple times now:
1. First click: Adds markers to map
2. Subsequent clicks: Updates zoom/position without re-adding markers
3. Accuracy circle still resizes properly with zoom changes

## Related
- Follows PR #21 (refactor trigger structure)