### PR TITLE
refactor: simplify onRemove method with optional chaining

### DIFF
--- a/src/MockGeolocateControl.ts
+++ b/src/MockGeolocateControl.ts
@@ -125,15 +125,13 @@ export class MockGeolocateControl implements IControl {
     this._removeMapEventListeners();
 
     // Clean up event listeners
-    if (this._button && this._onClickHandler) {
-      this._button.removeEventListener("click", this._onClickHandler);
+    if (this._onClickHandler) {
+      this._button?.removeEventListener("click", this._onClickHandler);
       this._onClickHandler = undefined;
     }
 
     // Remove DOM elements
-    if (this._container && this._container.parentNode) {
-      this._container.parentNode.removeChild(this._container);
-    }
+    this._container?.parentNode?.removeChild(this._container);
 
     // Remove markers from map
     this._positionMarker?.remove();


### PR DESCRIPTION
## Description

This PR refactors the `onRemove` method to use optional chaining, making the code cleaner and more consistent with the patterns established in PR #24.

## Changes

- **Event listener cleanup**: Simplified the conditional check by only checking for `_onClickHandler` existence, then using optional chaining on `_button`
- **DOM removal**: Replaced nested conditionals with chained optional operators (`?.`)
- **Consistent pattern**: Aligns with the optional chaining patterns used throughout the codebase

## Code Comparison

### Before:
```typescript
if (this._button && this._onClickHandler) {
  this._button.removeEventListener("click", this._onClickHandler);
  this._onClickHandler = undefined;
}

if (this._container && this._container.parentNode) {
  this._container.parentNode.removeChild(this._container);
}
```

### After:
```typescript
if (this._onClickHandler) {
  this._button?.removeEventListener("click", this._onClickHandler);
  this._onClickHandler = undefined;
}

this._container?.parentNode?.removeChild(this._container);
```

## Benefits

- **Reduced nesting**: Fewer conditional blocks make the code easier to read
- **Safer operations**: Optional chaining prevents potential runtime errors
- **Consistent style**: Matches the optional chaining pattern used for marker operations
- **Cleaner code**: Removes 2 lines while maintaining the same functionality

## Testing

- Verified that control removal works correctly when:
  - Button exists with event handler
  - Button is undefined but handler exists
  - Container has parent node
  - Container exists but has no parent
  - All cleanup operations complete successfully