### PR TITLE
Add toJSON helpers to mock geolocation events

### DIFF
--- a/src/MockGeolocateControl.ts
+++ b/src/MockGeolocateControl.ts
@@ -285,18 +285,39 @@ export class MockGeolocateControl implements IControl {
    * @private
    */
   private _createGeolocationPosition(): GeolocationPosition {
-    return {
-      coords: {
-        latitude: this._position.lat,
-        longitude: this._position.lng,
-        accuracy: this._accuracy,
+    const { lat, lng } = this._position;
+    const accuracy = this._accuracy;
+    const timestamp = Date.now();
+
+    const coords = {
+      latitude: lat,
+      longitude: lng,
+      accuracy,
+      altitude: null,
+      altitudeAccuracy: null,
+      heading: null,
+      speed: null,
+      toJSON: () => ({
+        latitude: lat,
+        longitude: lng,
+        accuracy,
         altitude: null,
         altitudeAccuracy: null,
         heading: null,
         speed: null,
-      },
-      timestamp: Date.now(),
-    } as GeolocationPosition;
+      }),
+    } satisfies GeolocationCoordinates;
+
+    const position = {
+      coords,
+      timestamp,
+      toJSON: () => ({
+        coords: coords.toJSON(),
+        timestamp,
+      }),
+    } satisfies GeolocationPosition;
+
+    return position;
   }
 
   /**


### PR DESCRIPTION
## Summary
- fix a behavioural gap where the mock emitted plain objects without the spec-defined `toJSON()` helpers, so consumers calling `event.coords.toJSON()` (which works with the real `GeolocateControl`) hit runtime errors
- mirror the browser `GeolocationPosition`/`GeolocationCoordinates` objects described by the Web Geolocation API (and surfaced in TypeScript's `lib.dom.d.ts` — see `GeolocationCoordinates`/`GeolocationPosition` definitions around [microsoft/TypeScript@main/lib/lib.dom.d.ts](https://github.com/microsoft/TypeScript/blob/v5.8.3/lib/lib.dom.d.ts#L9450-L9498)), which both include optional `toJSON()` methods
- construct the mock payload to match MapLibre's native control: reuse a single timestamp, attach `coords` (with its helper) and return the same structure from the top-level `toJSON()`, so swapping between the real and mock controls is seamless

## Testing
- not run (handled by CI)
