### PR TITLE
Fix: Use American English spelling in console message

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -138,7 +138,7 @@ map.on("load", () => {
   console.log("  - Blue position marker with white border");
   console.log("  - Semi-transparent accuracy circle");
   console.log("  - Event logs in console");
-  appendConsoleMessage("Map initialised. Ready to mock geolocation events.");
+  appendConsoleMessage("Map initialized. Ready to mock geolocation events.");
 });
 
 function fillInputs({ lng, lat }: { lng: number; lat: number }) {


### PR DESCRIPTION
## Summary
Fixed British English spelling "initialised" to American English "initialized" in the console output message.

## Changes
- Changed `"Map initialised. Ready to mock geolocation events."` to `"Map initialized. Ready to mock geolocation events."` in src/main.ts:141

## Rationale
Maintaining consistency with American English spelling conventions used throughout the codebase and in the wider JavaScript/TypeScript ecosystem.

## Test plan
- [x] Console message displays correctly with American English spelling
- [x] No functional changes, only spelling correction

🤖 Generated with [Claude Code](https://claude.com/claude-code)