### PR TITLE
fix: Update base path for custom domain

### DIFF
--- a/vite.config.demo.ts
+++ b/vite.config.demo.ts
@@ -2,7 +2,7 @@ import { defineConfig } from "vite";
 
 // Demo/GitHub Pages build configuration
 export default defineConfig({
-  base: "/maplibre-gl-manual-geolocate/",
+  base: "/",
   build: {
     outDir: "demo-dist",
   },


### PR DESCRIPTION
## Summary
- Updates Vite base path from `/maplibre-gl-manual-geolocate/` to `/` for custom domain deployment
- Fixes 404 errors and MIME type issues on https://maplibre-gl-manual-geolocate.mierune.dev/

## Details
Custom domains on GitHub Pages serve content from the root path, not from a repository subdirectory. The previous base path `/maplibre-gl-manual-geolocate/` was causing asset loading failures.

## Test plan
- [ ] Verify demo builds successfully
- [ ] Deploy to GitHub Pages and confirm assets load correctly on custom domain
- [ ] Verify no 404 errors in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)