### PR TITLE
Add npm package badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # maplibre-gl-manual-geolocate
 
+[![npm version](https://img.shields.io/npm/v/@mierune/maplibre-gl-manual-geolocate.svg)](https://www.npmjs.com/package/@mierune/maplibre-gl-manual-geolocate)
+
 [GitHub Repository](https://github.com/MIERUNE/maplibre-gl-mock-geolocate) | [Live Demo](https://maplibre-gl-manual-geolocate.mierune.dev/)
 
 A MapLibre GL JS control that displays a user position marker at specified coordinates without requiring the browser's [geolocation API](https://developer.mozilla.org/en-US/docs/Web/API/Geolocation_API). Provides the same visual appearance as the built-in [`GeolocateControl`](https://maplibre.org/maplibre-gl-js/docs/API/classes/GeolocateControl/) with complete control over positioning.


### PR DESCRIPTION
## Summary
- Added npm version badge to README displaying the current package version

This badge links to the npm package page and shows the latest published version.

## Test plan
- [x] Badge displays correctly in README
- [x] Badge links to correct npm package page

🤖 Generated with [Claude Code](https://claude.com/claude-code)