### PR TITLE
Add Live Demo link to Quick Start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ const manualGeolocateControl = new ManualGeolocateControl({
 map.addControl(manualGeolocateControl, "top-right");
 ```
 
-**Try it out:** Click the location button to center the map on Tokyo with automatic zoom-to-accuracy!
+**Try it out:** Check the [Live Demo](https://maplibre-gl-manual-geolocate.mierune.dev/) and click the location button to center the map on Tokyo with automatic zoom-to-accuracy!
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ const manualGeolocateControl = new ManualGeolocateControl({
 map.addControl(manualGeolocateControl, "top-right");
 ```
 
-**Try it out:** Check the [Live Demo](https://maplibre-gl-manual-geolocate.mierune.dev/) and click the location button to center the map on Tokyo with automatic zoom-to-accuracy!
+**Try it out:** Click the location button to center the map on Tokyo with automatic zoom-to-accuracy!
+
+**[Live Demo](https://maplibre-gl-manual-geolocate.mierune.dev/)**
 
 ---
 


### PR DESCRIPTION
## Summary
- Added a link to the live demo page in the Quick Start section

This makes it easier for users to quickly try out the control without setting up their own example.

## Test plan
- [x] Link displays correctly in README
- [x] Link points to correct demo URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)