### PR TITLE
Add Sapporo preset and make it the default

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -91,6 +91,12 @@ const POSITION_PRESETS: PositionPreset[] = [
     lng: -122.4194,
     lat: 37.7749,
   },
+  {
+    id: "sapporo",
+    label: "Sapporo, Japan",
+    lng: 141.3544924,
+    lat: 43.06417397,
+  },
   { id: "seoul", label: "Seoul, South Korea", lng: 126.978, lat: 37.5665 },
   { id: "singapore", label: "Singapore", lng: 103.8198, lat: 1.3521 },
   { id: "sydney", label: "Sydney, Australia", lng: 151.2093, lat: -33.8688 },
@@ -102,14 +108,14 @@ const map = new maplibregl.Map({
   container: "map",
   style:
     "https://mierune.github.io/rekichizu-style/styles/street-omt/style.json",
-  center: [139.74135747, 35.65809922], // Tokyo
+  center: [141.3544924, 43.06417397], // Sapporo
   zoom: 4,
   localIdeographFontFamily: false,
 });
 
 // Create manual geolocate control
 const manualGeolocateControl = new ManualGeolocateControl({
-  position: { lng: 139.74135747, lat: 35.65809922 }, // Tokyo
+  position: { lng: 141.3544924, lat: 43.06417397 }, // Sapporo
   accuracy: DEFAULT_ACCURACY,
   showAccuracyCircle: true,
 });
@@ -252,8 +258,8 @@ function populatePresetSelect() {
     select.appendChild(option);
   });
 
-  if (POSITION_PRESETS.some((preset) => preset.id === "tokyo")) {
-    select.value = "tokyo";
+  if (POSITION_PRESETS.some((preset) => preset.id === "sapporo")) {
+    select.value = "sapporo";
   }
 
   select.addEventListener("change", () => {
@@ -489,8 +495,8 @@ function setupFitBoundsControls() {
 
 populatePresetSelect();
 fillInputs({
-  lng: 139.741357,
-  lat: 35.658099,
+  lng: 141.3544924,
+  lat: 43.06417397,
 });
 setupFormHandlers();
 setupAccuracyControls();

--- a/src/main.ts
+++ b/src/main.ts
@@ -94,8 +94,8 @@ const POSITION_PRESETS: PositionPreset[] = [
   {
     id: "sapporo",
     label: "Sapporo, Japan",
-    lng: 141.3544924,
-    lat: 43.06417397,
+    lng: 141.345661,
+    lat: 43.05907,
   },
   { id: "seoul", label: "Seoul, South Korea", lng: 126.978, lat: 37.5665 },
   { id: "singapore", label: "Singapore", lng: 103.8198, lat: 1.3521 },
@@ -108,14 +108,14 @@ const map = new maplibregl.Map({
   container: "map",
   style:
     "https://mierune.github.io/rekichizu-style/styles/street-omt/style.json",
-  center: [141.3544924, 43.06417397], // Sapporo
+  center: [141.345661, 43.05907], // Sapporo
   zoom: 4,
   localIdeographFontFamily: false,
 });
 
 // Create manual geolocate control
 const manualGeolocateControl = new ManualGeolocateControl({
-  position: { lng: 141.3544924, lat: 43.06417397 }, // Sapporo
+  position: { lng: 141.345661, lat: 43.05907 }, // Sapporo
   accuracy: DEFAULT_ACCURACY,
   showAccuracyCircle: true,
 });
@@ -495,8 +495,8 @@ function setupFitBoundsControls() {
 
 populatePresetSelect();
 fillInputs({
-  lng: 141.3544924,
-  lat: 43.06417397,
+  lng: 141.345661,
+  lat: 43.05907,
 });
 setupFormHandlers();
 setupAccuracyControls();


### PR DESCRIPTION
## Summary
- Added Sapporo, Japan to the position presets dropdown
- Changed the default position from Tokyo to Sapporo

## Changes
- Added new preset: Sapporo, Japan (141.3544924, 43.06417397)
- Updated map center to Sapporo
- Updated control initial position to Sapporo
- Updated dropdown default selection to Sapporo
- Updated coordinate input fields to show Sapporo coordinates by default

## Test plan
- [x] Demo page loads with Sapporo as the center
- [x] Preset dropdown shows "Sapporo, Japan" selected by default
- [x] Coordinate inputs show Sapporo coordinates
- [x] All other presets still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)