### PR TITLE
Fix OG image URL to use absolute path

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,10 @@
             property="og:description"
             content="A MapLibre GL JS control that displays a user position marker at specified coordinates without requiring the browser's geolocation API"
         />
-        <meta property="og:image" content="/og-image.png" />
+        <meta
+            property="og:image"
+            content="https://maplibre-gl-manual-geolocate.mierune.dev/og-image.png"
+        />
 
         <!-- Twitter -->
         <meta property="twitter:card" content="summary_large_image" />
@@ -47,7 +50,10 @@
             property="twitter:description"
             content="A MapLibre GL JS control that displays a user position marker at specified coordinates without requiring the browser's geolocation API"
         />
-        <meta property="twitter:image" content="/og-image.png" />
+        <meta
+            property="twitter:image"
+            content="https://maplibre-gl-manual-geolocate.mierune.dev/og-image.png"
+        />
     </head>
     <body>
         <!-- Header -->


### PR DESCRIPTION
## Summary
- Fixed og:image and twitter:image to use absolute URLs instead of relative paths

## Issue
Social media platforms require absolute URLs (with full domain) to fetch OG images. The previous relative path `/og-image.png` wouldn't work for social sharing.

## Changes
- Changed `og:image` from `/og-image.png` to `https://maplibre-gl-manual-geolocate.mierune.dev/og-image.png`
- Changed `twitter:image` from `/og-image.png` to `https://maplibre-gl-manual-geolocate.mierune.dev/og-image.png`

## Test plan
- [x] Verified absolute URLs are correctly formatted
- Social media debuggers can now properly fetch the OG image:
  - Facebook Sharing Debugger: https://developers.facebook.com/tools/debug/
  - Twitter Card Validator: https://cards-dev.twitter.com/validator

🤖 Generated with [Claude Code](https://claude.com/claude-code)