### PR TITLE
Add GitHub Actions workflow for npm publishing

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -21,36 +21,21 @@ This document describes how to publish a new version of `@mierune/maplibre-gl-ma
 
 ## Publishing a New Release
 
-### 1. Update Version
-
-Update the version in `package.json`:
-
-```json
-{
-  "version": "0.2.0"  // Change from 0.1.0 to your new version
-}
-```
-
-Commit and push to main:
-
-```bash
-git add package.json
-git commit -m "chore: bump version to 0.2.0"
-git push origin main
-```
-
-### 2. Create GitHub Release
+### 1. Create GitHub Release
 
 1. Go to https://github.com/MIERUNE/maplibre-gl-manual-geolocate/releases/new
-2. Click "Choose a tag" and type the new version (e.g., `v0.2.0`)
+2. Click "Choose a tag" and type the new version with `v` prefix (e.g., `v0.2.0`)
+   - ⚠️ **Important:** Tag must start with `v` (e.g., `v0.2.0`, not `0.2.0`)
 3. Click "Create new tag: v0.2.0 on publish"
 4. Set the release title (e.g., `v0.2.0`)
 5. Add release notes describing changes
 6. Click "Publish release"
 
-### 3. Automatic Publishing
+### 2. Automatic Version Update & Publishing
 
 The GitHub Action will automatically:
+- ✅ Extract version from the tag (e.g., v0.2.0 → 0.2.0)
+- ✅ Update `package.json` with the version
 - ✅ Build the library
 - ✅ Run tests
 - ✅ Publish to npm
@@ -58,7 +43,7 @@ The GitHub Action will automatically:
 You can monitor progress at:
 https://github.com/MIERUNE/maplibre-gl-manual-geolocate/actions
 
-### 4. Verify Publication
+### 3. Verify Publication
 
 After the action completes, verify the new version is live:
 - npm: https://www.npmjs.com/package/@mierune/maplibre-gl-manual-geolocate
@@ -80,8 +65,8 @@ Follow [Semantic Versioning](https://semver.org/):
 - Ensure the token has "Automation" permissions
 
 ### Action fails with "Version already exists"
-- Make sure you bumped the version in `package.json`
-- Check that the git tag matches the package.json version
+- The version from the tag already exists on npm
+- Create a new release with a higher version number
 
 ### Tests fail
 - Fix the failing tests before creating the release

--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -1,0 +1,88 @@
+# Release Process
+
+This document describes how to publish a new version of `@mierune/maplibre-gl-manual-geolocate` to npm.
+
+## Prerequisites
+
+### One-time Setup: NPM Token
+
+1. **Generate an npm access token:**
+   - Go to https://www.npmjs.com/settings/YOUR_USERNAME/tokens
+   - Click "Generate New Token" → "Classic Token"
+   - Select "Automation" type (for CI/CD publishing)
+   - Copy the token (starts with `npm_...`)
+
+2. **Add token to GitHub:**
+   - Go to https://github.com/MIERUNE/maplibre-gl-manual-geolocate/settings/secrets/actions
+   - Click "New repository secret"
+   - Name: `NPM_TOKEN`
+   - Value: Paste your npm token
+   - Click "Add secret"
+
+## Publishing a New Release
+
+### 1. Update Version
+
+Update the version in `package.json`:
+
+```json
+{
+  "version": "0.2.0"  // Change from 0.1.0 to your new version
+}
+```
+
+Commit and push to main:
+
+```bash
+git add package.json
+git commit -m "chore: bump version to 0.2.0"
+git push origin main
+```
+
+### 2. Create GitHub Release
+
+1. Go to https://github.com/MIERUNE/maplibre-gl-manual-geolocate/releases/new
+2. Click "Choose a tag" and type the new version (e.g., `v0.2.0`)
+3. Click "Create new tag: v0.2.0 on publish"
+4. Set the release title (e.g., `v0.2.0`)
+5. Add release notes describing changes
+6. Click "Publish release"
+
+### 3. Automatic Publishing
+
+The GitHub Action will automatically:
+- ✅ Build the library
+- ✅ Run tests
+- ✅ Publish to npm
+
+You can monitor progress at:
+https://github.com/MIERUNE/maplibre-gl-manual-geolocate/actions
+
+### 4. Verify Publication
+
+After the action completes, verify the new version is live:
+- npm: https://www.npmjs.com/package/@mierune/maplibre-gl-manual-geolocate
+- Or run: `npm view @mierune/maplibre-gl-manual-geolocate version`
+
+## Version Guidelines
+
+Follow [Semantic Versioning](https://semver.org/):
+
+- **Patch** (0.1.0 → 0.1.1): Bug fixes, documentation updates
+- **Minor** (0.1.0 → 0.2.0): New features (backwards compatible)
+- **Major** (0.1.0 → 1.0.0): Breaking changes
+
+## Troubleshooting
+
+### Action fails with "401 Unauthorized"
+- Check that `NPM_TOKEN` secret is set correctly
+- Verify the token hasn't expired
+- Ensure the token has "Automation" permissions
+
+### Action fails with "Version already exists"
+- Make sure you bumped the version in `package.json`
+- Check that the git tag matches the package.json version
+
+### Tests fail
+- Fix the failing tests before creating the release
+- The workflow will not publish if tests fail

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,20 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Extract version from tag
+        id: get_version
+        run: |
+          # Remove 'v' prefix from tag (e.g., v0.2.0 -> 0.2.0)
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "Publishing version: $VERSION"
+
+      - name: Update package.json version
+        run: |
+          # Update version in package.json
+          npm version ${{ steps.get_version.outputs.VERSION }} --no-git-tag-version
+          echo "Updated package.json to version ${{ steps.get_version.outputs.VERSION }}"
+
       - name: Build library
         run: pnpm build
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          standalone: true
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Restore pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build library
+        run: pnpm build
+
+      - name: Run tests
+        run: pnpm test:coverage
+
+      - name: Publish to npm
+        run: pnpm publish --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -480,8 +480,13 @@ The project uses GitHub Actions for continuous integration and deployment:
 - **Test** - Runs unit tests with Vitest
 - **Build** - Compiles TypeScript and builds the library
 - **Deploy Demo** - Automatically deploys the demo to GitHub Pages on push to main
+- **Publish** - Automatically publishes to npm when a GitHub Release is created
 
 All workflows run on pull requests to ensure code quality before merging.
+
+### Publishing Releases
+
+See [RELEASE.md](.github/RELEASE.md) for instructions on how to publish new versions to npm.
 
 ---
 


### PR DESCRIPTION
## Summary
- Added automated npm publishing workflow that triggers on GitHub Release
- **Workflow automatically syncs version from release tag to package.json**
- Includes comprehensive release documentation

## What's Included

### 1. GitHub Actions Workflow (`.github/workflows/publish.yml`)
- Triggers when you create a GitHub Release
- **Automatically extracts version from tag (e.g., v0.2.0 → 0.2.0)**
- **Updates package.json with the version**
- Runs build and tests before publishing
- Publishes to npm using `NPM_TOKEN` secret

### 2. Release Documentation (`.github/RELEASE.md`)
Complete guide covering:
- One-time NPM_TOKEN setup
- Simplified release process (just create GitHub Release!)
- Version guidelines (semantic versioning)
- Troubleshooting tips

## How to Use (After Merging)

### One-Time Setup
1. Generate npm access token at https://www.npmjs.com/settings/tokens
   - Use "Automation" type for CI/CD
2. Add token to GitHub repository secrets:
   - Go to Settings → Secrets and variables → Actions
   - Create new secret: `NPM_TOKEN` with your token

### Publishing a Release (Simplified!)
1. Create GitHub Release with version tag (e.g., `v0.2.0`)
   - ⚠️ Tag must start with `v`
2. That's it! Workflow automatically:
   - Updates package.json to 0.2.0
   - Builds and tests
   - Publishes to npm

**No need to manually update package.json!** The version is automatically synced from the GitHub Release tag.

See `.github/RELEASE.md` for detailed instructions.

## Security
- Uses npm automation token (safer than personal access token)
- Token stored as GitHub secret (encrypted)
- Workflow only has read permissions except for npm publish

## Test Plan
- [x] Workflow file syntax is valid
- [x] Uses existing build and test commands
- [x] Auto-version extraction from tag
- [ ] To test after merge: Create a test release to verify workflow runs (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)