### PR TITLE
Auto-commit version changes back to repository

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -36,6 +36,7 @@ This document describes how to publish a new version of `@mierune/maplibre-gl-ma
 The GitHub Action will automatically:
 - ✅ Extract version from the tag (e.g., v0.2.0 → 0.2.0)
 - ✅ Update `package.json` with the version
+- ✅ Commit and push the version change back to main
 - ✅ Build the library
 - ✅ Run tests
 - ✅ Publish to npm

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 permissions:
-  contents: read
+  contents: write  # Allow pushing version changes back to repo
 
 jobs:
   publish:
@@ -54,6 +54,14 @@ jobs:
           # Update version in package.json
           npm version ${{ steps.get_version.outputs.VERSION }} --no-git-tag-version
           echo "Updated package.json to version ${{ steps.get_version.outputs.VERSION }}"
+
+      - name: Commit version change
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add package.json
+          git commit -m "chore: bump version to ${{ steps.get_version.outputs.VERSION }}"
+          git push
 
       - name: Build library
         run: pnpm build


### PR DESCRIPTION
## Summary
- Updates the npm publish workflow to commit version changes back to the repository
- Ensures `package.json` in the repo stays in sync with published npm versions

## Problem
After merging #61, the workflow successfully publishes to npm but doesn't update `package.json` in the repository. This means:
- GitHub Release tag: v0.2.0
- npm version: 0.2.0 ✅
- Repository package.json: 0.1.0 ❌ (out of sync)

## Solution
This PR adds a commit step to push the version change back to the repository after updating `package.json`.

## Changes

### Updated `.github/workflows/publish.yml`
- Changed permissions from `contents: read` to `contents: write`
- Added "Commit version change" step after updating package.json
- Commits are made by `github-actions[bot]`
- Commit message format: `chore: bump version to X.Y.Z`

### Updated `.github/RELEASE.md`
- Added documentation about the automatic commit step

## How It Works

When you create a GitHub Release (e.g., `v0.2.1`):

1. ✅ Extract version from tag (v0.2.1 → 0.2.1)
2. ✅ Update package.json to 0.2.1
3. ✅ **Commit and push to main** ← New!
4. ✅ Build library
5. ✅ Run tests
6. ✅ Publish to npm

## Result
After this change, your repository's `package.json` will always match the published npm version. You'll see automatic commits like:
```
chore: bump version to 0.2.1
```
authored by `github-actions[bot]`.

## Test Plan
- [x] Workflow syntax is valid
- [x] Permissions updated to allow writing
- [x] Commit step configured correctly
- [ ] Will be tested on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)