### PR TITLE
Fix detached HEAD error when committing version changes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,11 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
           echo "Publishing version: $VERSION"
 
+      - name: Checkout main branch
+        run: |
+          git fetch origin main
+          git checkout main
+
       - name: Update package.json version
         run: |
           # Update version in package.json
@@ -61,7 +66,7 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git add package.json
           git commit -m "chore: bump version to ${{ steps.get_version.outputs.VERSION }}"
-          git push
+          git push origin main
 
       - name: Build library
         run: pnpm build


### PR DESCRIPTION
## Problem

The publish workflow is failing with this error when trying to commit the version change:
```
fatal: You are not currently on a branch.
To push the history leading to the current (detached HEAD)
state now, use

    git push origin HEAD:<name-of-remote-branch>

Error: Process completed with exit code 128.
```

**Root cause:** The workflow checks out the release tag (via `actions/checkout@v4`), which puts it in a detached HEAD state. When it tries to `git push`, it fails because it's not on a branch.

**Evidence:** `package.json` is still at version 0.1.0 even though v0.2.1 was released.

## Solution

Added a step to checkout the main branch before updating `package.json`:

```yaml
- name: Checkout main branch
  run: |
    git fetch origin main
    git checkout main
```

This ensures we're on the main branch when committing and pushing.

## Updated Workflow

1. Extract version from tag (v0.2.1 → 0.2.1)
2. **Fetch and checkout main branch** ← Fix!
3. Update package.json
4. Commit and push to main
5. Build, test, publish to npm

## Test Plan

- [x] Workflow syntax is valid
- [x] Explicitly checks out main before modifying files
- [x] Pushes to `origin main` explicitly
- [ ] Will be tested on next release

## Note

This fix was in my previous PR branch but didn't make it into the merge. This PR adds back the missing step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)