### PR TITLE
Use Personal Access Token to bypass branch protection

### DIFF
--- a/.github/RELEASE.md
+++ b/.github/RELEASE.md
@@ -4,7 +4,9 @@ This document describes how to publish a new version of `@mierune/maplibre-gl-ma
 
 ## Prerequisites
 
-### One-time Setup: NPM Token
+### One-time Setup: Required Tokens
+
+#### 1. NPM Token
 
 1. **Generate an npm access token:**
    - Go to https://www.npmjs.com/settings/YOUR_USERNAME/tokens
@@ -17,6 +19,26 @@ This document describes how to publish a new version of `@mierune/maplibre-gl-ma
    - Click "New repository secret"
    - Name: `NPM_TOKEN`
    - Value: Paste your npm token
+   - Click "Add secret"
+
+#### 2. Release PAT (Personal Access Token)
+
+This is needed to bypass branch protection rules when committing version changes.
+
+1. **Generate a Personal Access Token:**
+   - Go to https://github.com/settings/tokens/new
+   - Token name: `Release Automation`
+   - Expiration: Choose your preference (recommend 1 year or no expiration)
+   - Select scopes:
+     - ✅ `repo` (Full control of private repositories)
+   - Click "Generate token"
+   - Copy the token (starts with `ghp_...` or `github_pat_...`)
+
+2. **Add token to GitHub:**
+   - Go to https://github.com/MIERUNE/maplibre-gl-manual-geolocate/settings/secrets/actions
+   - Click "New repository secret"
+   - Name: `RELEASE_PAT`
+   - Value: Paste your personal access token
    - Click "Add secret"
 
 ## Publishing a New Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Problem

The workflow is failing to push version commits because of branch protection rules:
```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
```

Adding "Repository admin" to the bypass list didn't work because the default `GITHUB_TOKEN` doesn't have sufficient privileges.

## Solution

Use a Personal Access Token (PAT) with admin rights instead of the default `GITHUB_TOKEN`.

## Changes

### Updated `.github/workflows/publish.yml`
- Modified checkout action to use `RELEASE_PAT` secret
- This PAT has the privileges needed to bypass branch protection

### Updated `.github/RELEASE.md`
- Added complete instructions for creating a PAT
- Documented how to add it as a repository secret

## Setup Required (One-Time)

After merging this PR, you need to:

1. **Create a Personal Access Token:**
   - Go to https://github.com/settings/tokens/new
   - Name: `Release Automation`
   - Expiration: Your preference (recommend 1 year or no expiration)
   - Scope: Check `repo` (Full control of private repositories)
   - Click "Generate token"
   - **Copy the token** (you won't see it again!)

2. **Add Token to Repository:**
   - Go to https://github.com/MIERUNE/maplibre-gl-manual-geolocate/settings/secrets/actions
   - Click "New repository secret"
   - Name: `RELEASE_PAT`
   - Value: Paste your token
   - Click "Add secret"

## How It Works

When the workflow runs:
1. Uses `RELEASE_PAT` for checkout (this token has admin rights)
2. Git operations (commit, push) use this PAT automatically
3. PAT bypasses branch protection because it has admin privileges
4. Version commit successfully pushes to main

## Test Plan

- [x] Workflow syntax is valid
- [x] Checkout uses RELEASE_PAT
- [x] Documentation updated with setup instructions
- [ ] After setup: Test with next release (e.g., v0.2.4)

## Why PAT Over GITHUB_TOKEN?

The default `GITHUB_TOKEN` has limited permissions and can't bypass branch protection rules even when "Repository admin" is added to the bypass list. A PAT created by a repository admin has the necessary privileges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)