### PR TITLE
fix: add types field to package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/maplibre-gl-manual-geolocate.js",
       "require": "./dist/maplibre-gl-manual-geolocate.umd.cjs"
     }


### PR DESCRIPTION
## Summary
- Adds explicit `types` field to the `exports` configuration in package.json
- Fixes TypeScript type definitions not being resolved when the package is consumed in other projects

## Test plan
- [ ] Install the package in another project after this change
- [ ] Verify that TypeScript type definitions are properly available
- [ ] Check that IDE autocomplete and type checking work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)